### PR TITLE
New line added between inputs. Setted password reading as silent.

### DIFF
--- a/connect-cli.sh
+++ b/connect-cli.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 LIST=$(nmcli device wifi list)
 echo "$LIST"
-echo "SSID:"
-read SSID
-echo "Password, if none, hit Enter:"
-read PASS
+read -p "> SSID: " SSID
+read -sp "> Password, if none, hit Enter:" PASS
+echo -e "\nTrying to connect..."
+
 if [ -z "$PASS" ]
 then
 	nmcli device wifi connect "$SSID"


### PR DESCRIPTION
Hi
I've been looking for an wifi/ethernet manager on CLI, and yours looked cool. I tried to modify it to my taste, but it may be useful with this modifications to somebody else. Anyway, this is also just a first try on a pull request, so no big deal of a change :)

I basically positioned the input/read part on the same line of the "SSID" and "password" prompts, and added a little message at the end so the user can get a feedback that the password actually went trought (since now is in silent input)

Btw, the script was tested in bash and zsh, but it only works on bash

Comments are well recieved!